### PR TITLE
proto: fix vet error

### DIFF
--- a/go-proto/rootlesscontainers_generate.go
+++ b/go-proto/rootlesscontainers_generate.go
@@ -32,6 +32,6 @@ var NoopID uint32 = 0xFFFFFFFF
 // IsDefault returns whether the given Resource is the default. If a Resource
 // is equal to the default Resource then it is not necesary to include it on
 // the filesystem.
-func IsDefault(r Resource) bool {
+func IsDefault(r *Resource) bool {
 	return r.Uid == NoopID && r.Gid == NoopID
 }


### PR DESCRIPTION
go vet ./...
# github.com/rootless-containers/proto/go-proto
./rootlesscontainers_generate.go:35:18: IsDefault passes lock by value: github.com/rootless-containers/proto/go-proto.Resource contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex

let's change this method to have a pointer receiver so we don't copy the mutex.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>