### PR TITLE
Update reference to a current PRoot fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ The following is a list of known projects that support
   manner). Version `0.4.0` and later have full `user.rootlesscontainers`
   support, both with `umoci unpack` and `umoci repack`.
 
-* [Our fork of PRoot][proot-fork] with a few patches applied. `PRoot` allows
+* [The Apptainer fork of proot][proot-fork] with a few patches applied. `PRoot` allows
   for full emulation (through `ptrace` with optional `seccomp` acceleration) of
   all privilege operations that would produce "strange" results inside a
   rootless container. This is a perfect fit for rootless containers.
 
 [umoci]: https://github.com/openSUSE/umoci
-[proot-fork]: https://github.com/rootless-containers/PRoot
+[proot-fork]: https://github.com/apptainer/PRoot
 
 ### License ###
 


### PR DESCRIPTION
Because the rootlesscontainers/PRoot fork has long been archived and I wanted to use it as part of the Apptainer SIF container build process, I have brought it up to date with the latest proot-me/proot upstream and created a new fork at apptainer/PRoot.  This PR updates the reference to point to the new, current fork.

Alternatively, if I could become the owner of the archived rootlesscontainers/PRoot repository I would unarchive it, update it, and maintain the PRoot fork there.  That would be my preference, and then I would delete the apptainer/PRoot fork and close this pull request.
